### PR TITLE
Jupyterhub docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,9 +156,8 @@ jobs:
       # TODO: also add CORE tests!
       # TODO: GPU tests are failing even with nvidia run-time https://github.com/SyneRBI/SIRF-SuperBuild/issues/553
       if [[ "$DOCKER_BUILD" != *"CORE"* && "$DOCKER_BUILD" != *"GPU"* ]]; then
-        # disable for now
-        #$DCC run --rm sirf /bin/bash --login -c '/devel/test.sh 1'
-        true
+        # Need to run as jovyan to be able to write to build directory (needed by ctest)
+        $DCC run --rm -u jovyan --entrypoint /bin/bash sirf --login -c /devel/test.sh 1
       fi
    after_success: &docker_after_success
    - |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,9 +8,9 @@
     {"identifier": "10.5281/zenodo.2707911", "relation": "software"}],
   "communities": [{"identifier": "ccp-petmr"},{"identifier": "synerbi"}],
   "creators": [
-    {"name": "Thomas, Benjamin A.", "orcid": "0000-0002-9784-1177", "affiliation": "University College London"},
-    {"name": "Pasca, Edoardo", "orcid": "0000-0001-6957-2160", "affiliation":"UK Research & Innovation"},
     {"name": "da Costa-Luis, Casper O.", "orcid": "0000-0002-7211-1557", "affiliation": "King's College London"},
+    {"name": "Pasca, Edoardo", "orcid": "0000-0001-6957-2160", "affiliation":"UK Research & Innovation"},
+    {"name": "Thomas, Benjamin A.", "orcid": "0000-0002-9784-1177", "affiliation": "University College London"},
     {"name": "Brown, Richard", "orcid": "0000-0001-6989-9200", "affiliation": "University College London"},
     {"name": "Biguri, Ander", "orcid": "0000-0002-2636-3032", "affiliation": "University College London"},
     {"name": "Ovtchinnikov, Evgueni", "affiliation":"UK Research & Innovation"},

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,19 @@
 # ChangeLog
 
-## v3.x.x
-- disable built of NiftyPET by default as requires Python2 for which we dropped support
+## v3.1.0
 - docker:
-  - major change w.r.t. users and permissions. We know build as user jovyan (by default)
-    and still switch to sirfuser for running the container. This avoids having to
+  - major change w.r.t. users and permissions. We now build as user `jovyan` (by default)
+    and still switch to `sirfuser` for running the container. This avoids having to
     reset permissions of many files, and therefore speeds-up container start-up.
   - introduced `SIRF_SB_URL`, `SIRF_SB_TAG` and `NUM_PARALLEL_BUILDS`. They default to the
     values used before (i.e. resp. the main `SIRF-SuperBuild` repo, `master` and `2`).
   - add dependencies that are available only from conda-forge (for CIL)
-- allow specifying `HDF5_URL` and `HDF5_TAG` like for others
+  - improved documentation
+- allow specifying `HDF5_URL` and `HDF5_TAG` like for other projects
 - updated versions:
   - SIRF: 3.1.0
   - CIL: xxxx
+- disable built of NiftyPET by default as our current setup  requires Python2 for which we dropped support
 
 ## v3.0.0
 - travis to use BUILD_CIL=ON for all Docker builds

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 - allow specifying `HDF5_URL` and `HDF5_TAG` like for other projects
 - updated versions:
   - SIRF: 3.1.0
-  - CIL: ca12ef252e68eaa7a3cccd19250e5481f02bcfd2
+  - CIL: b81326291c6061d57fa332a248cb9d15d9f957eb
   - CIL-ASTRA: 21.2.0
 - disable built of NiftyPET by default as our current setup  requires Python2 for which we dropped support
 - Continuous Integration testing:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   - major change w.r.t. users and permissions. We know build as user jovyan (by default)
     and still switch to sirfuser for running the container. This avoids having to
     reset permissions of many files, and therefore speeds-up container start-up.
+  - introduced `SIRF_SB_URL`, `SIRF_SB_TAG` and `NUM_PARALLEL_BUILDS`. They default to the
+    values used before (i.e. resp. the main `SIRF-SuperBuild` repo, `master` and `2`).
   - add dependencies that are available only from conda-forge (for CIL)
 - allow specifying `HDF5_URL` and `HDF5_TAG` like for others
 - updated versions:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,10 @@
     and still switch to sirfuser for running the container. This avoids having to
     reset permissions of many files, and therefore speeds-up container start-up.
   - add dependencies that are available only from conda-forge (for CIL)
-- updated ISMRMRD to 1.4.2.1
+- allow specifying `HDF5_URL` and `HDF5_TAG` like for others
+- updated versions:
+  - SIRF: 3.1.0
+  - CIL: xxxx
 
 ## v3.0.0
 - travis to use BUILD_CIL=ON for all Docker builds

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,12 +12,14 @@
 - allow specifying `HDF5_URL` and `HDF5_TAG` like for other projects
 - updated versions:
   - SIRF: 3.1.0
-  - CIL: xxxx
+  - CIL: ca12ef252e68eaa7a3cccd19250e5481f02bcfd2
+  - CIL-ASTRA: 21.2.0
 - disable built of NiftyPET by default as our current setup  requires Python2 for which we dropped support
+- Continuous Integration testing:
+    - Removed all Travis runs except those that run docker
 
 ## v3.0.0
-- travis to use BUILD_CIL=ON for all Docker builds
-- Add GitHub action for CI. 
+- use BUILD_CIL=ON for all Docker builds
 - Docker build moved to Python3 only.
 - Environment files with name env_sirf.sh (and csh) are created. Symbolic links or copies with the previous name env_ccppetmr.sh (and csh) depending on the version of CMake available are made.
 - Fix some issues with finding Python [#472](https://github.com/SyneRBI/SIRF-SuperBuild/issues/472)
@@ -38,7 +40,7 @@
    - CIL: 21.1.0
    - CCPi-Regularisation toolkit: 20.09
 - Continuous Integration testing:
-    - Add GitHub actions and removed most Travs runs
+    - Add GitHub actions and removed most Travis runs
     - Switched Travis ctest from --verbose to --output-on-failure and added travis_wait of 20 minutes to keep it from timing-out if some tests take longer than 10.
 
 ## v2.2.0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,10 +10,10 @@ at RAL STFC (http://www.stfc.ac.uk), UCL (http://www.ucl.ac.uk/)
 and other contributing institutions.
 
 Main contributors (see each file for authors):
-Kris Thielemans (UCL)
-Benjamin A Thomas(UCL)
-Edoardo Pasca (STFC)
 Casper da Costa-Luis (KCL)
+Kris Thielemans (UCL)
+Edoardo Pasca (STFC)
+Benjamin A Thomas(UCL)
 Ander Biguri (UCL)
 Richard Brown (UCL)
 Evgueni Ovtchinnikov (STFC)

--- a/SuperBuild/External_CIL-ASTRA.cmake
+++ b/SuperBuild/External_CIL-ASTRA.cmake
@@ -57,7 +57,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${externalProjName}" AND "${USE_SYSTEM_${externalPr
 
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
-      INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory ${${proj}_SOURCE_DIR}/Wrappers/Python/cil/plugins/astra ${PYTHON_DEST}/cil/plugins/astra
+      INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir ${${proj}_SOURCE_DIR}/Wrappers/Python/ ${PYTHON_EXECUTABLE} setup.py install --install-lib ${PYTHON_DEST}
       CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${${proj}_INSTALL_DIR}
       DEPENDS ${${proj}_DEPENDENCIES}
     )

--- a/docker/.bashrc
+++ b/docker/.bashrc
@@ -29,7 +29,7 @@ export PS1='sirf$ '
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/pyvenv/lib
 
 # .local/bin (used by pip for instance)
-export PATH="${PATH}:~/.local/bin"
+export PATH="${PATH}":~/.local/bin
 
 # shared permissions
 # [ $(ls -l / | grep devel | awk '{print $3}') == $(whoami) ] || sudo chown -R $(whoami) /devel

--- a/docker/DocForDevelopers.md
+++ b/docker/DocForDevelopers.md
@@ -1,5 +1,25 @@
 # Extra information on the SIRF Docker set-up for developers
 
+## Useful environment variables
+You can determine which version of the `SIRF-SuperBuild` is built in the docker image, in `bash` and similar shells:
+```bash
+export SIRF_SB_TAG=v3.1.0
+```
+You can use a `git` hash as well of course. You can also set where to `clone` from:
+```bash
+export SIRF_SB_URL=https://github.com/KrisThielemans/SIRF-SuperBuild
+```
+If you have many cores, you can speed-up the build by saying
+```bash
+export NUM_PARALLEL_BUILDS=9
+```
+This will be passed to `cmake --build -j`.
+
+Of course, if you are using `bash`, you can specify any of these for a specific run, e.g.
+```
+NUM_PARALLEL_BUILDS=9 ./sirf-compose build sirf
+```
+
 ## `ccache`
 
 `ccache` is used in the container to speed up rebuilding images from scratch.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,6 +114,13 @@ USER "${NB_USER}"
 RUN ccache -o cache_dir=/opt/ccache
 COPY user_sirf-ubuntu.sh .
 
+# SIRF-SuperBuild version
+ARG SIRF_SB_URL="https://github.com/SyneRBI/SIRF-SuperBuild"
+ARG SIRF_SB_TAG="master"
+# speeding up the cmake build
+# (implementation note: changing this in your environment will invalidate the docker cache sadly)
+ARG NUM_PARALLEL_BUILDS="2"
+
 ARG BUILD_FLAGS="\
  -DCMAKE_BUILD_TYPE=Release\
  -DBUILD_STIR_WITH_OPENMP=ON -DUSE_SYSTEM_ACE=ON\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -215,7 +215,7 @@ ENTRYPOINT ["/tini", "-g", "--"]
 # CMD ["/usr/local/bin/service-jupyterhub.sh"]
 
 # set some env variables (or do it in a compose file)
-USER ${NB_UID} 
+USER ${NB_USER}
 ENV PATH "/opt/pyvenv/bin:$PATH"
 ENV LD_LIBRARY_PATH "/opt/SIRF-SuperBuild/INSTALL/lib:/opt/SIRF-SuperBuild/INSTALL/lib64:/opt/pyvenv/lib/:$LD_LIBRARY_PATH"
 ENV PYTHONPATH "/opt/SIRF-SuperBuild/INSTALL/python"

--- a/docker/README.md
+++ b/docker/README.md
@@ -143,7 +143,15 @@ A brief list of everything important to know for a basic working knowledge of do
 
 The docker images can be built from source or pulled using `SyneRBI/SIRF-SuperBuild`, and containers created, by following the steps below.
 
-Please note that these instructions will mount the `SIRF-SuperBuild/docker/devel` folder on the host as `/devel` in the docker container.
+**Warnings**:
+
+When building an image yourself, by default the current `master` branch of the `SIRF-SuperBuild` is used. It might be
+safer to specify a tag. This can be done by first setting an environment variable. e.g. in `bash` and similar shells:
+```bash
+export SIRF_SB_TAG=v3.1.0
+```
+
+These instructions will mount the `SIRF-SuperBuild/docker/devel` folder on the host as `/devel` in the docker container.
 When using a `service*` image, the container will copy
 [SIRF-Exercises] into this folder if not present. This means that
 files and notebooks in `/devel` will be persistent between sessions and
@@ -294,9 +302,11 @@ docker rmi <IMAGEID>
 ```
 - Currently all `compose` files call the container `sirf`. You could edit the `.yml` file if you
 want to run different versions.
-- "Cannot connect to display" errors are usually fixed by running `xhost +local:""` on the host linux system
-- Non-linux users (e.g. Windows) will need to set up a desktop and vnc server in order to have a GUI
-- On host systems with less than 16GB RAM, before `docker-compose up ...` you may want to edit `SIRF-SuperBuild/docker/user_sirf-ubuntu.sh`, changing the line `make -j...` to simply `make`. This increases build time and reduces build memory requirements
+- "Cannot connect to display" errors are usually fixed by running `xhost +local:""` on the host linux system.
+- Non-linux users (e.g. Windows) will need to set up a desktop and vnc server in order to have a GUI.
+- On host systems with less than 16GB RAM, you might want to set the number of parallel builds used by cmake when creating
+the image to `1` (it currently defaults to `2`) by [setting an environment variable](./DocForDevelopers.md#Useful-environment-variables)
+before running `compose`.
 
 ### Links
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -178,13 +178,13 @@ Here, `--no-start` delays actually starting the container.
 We can now use this interactively, by starting the containder with flags `-ai`.
 ```bash
 SIRF-SuperBuild/docker$ docker start -ai sirf
-(py2) sirf:~$ gadgetron >> /dev/null &  # we are free to use tools like Gadgetron
-(py2) sirf:~$ python SIRF-SuperBuild/SIRF/examples/Python/MR/fully_sampled_recon.py  # or SIRF
+(py2) sirf:~$ gadgetron >> /dev/null &  # launch Gadgetron as a "background" process
+(py2) sirf:~$ python SIRF-SuperBuild/SIRF/examples/Python/MR/fully_sampled_recon.py  # run a SIRF demo
 (py2) sirf:~$ exit
 ```
 
 The first line starts the `sirf` docker container.
-The second line starts `gadgetron` within the container as a background process (optional, but needed for using Gadgetron of course).
+The second line starts `gadgetron` within the container as a background process (optional, but needed for using Gadgetron, i.e. most SIRF MR functionality).
 We can then run an example (or you could start an interactive python session).
 We then exit the container (which also stops it).
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -144,7 +144,7 @@ A brief list of everything important to know for a basic working knowledge of do
 The docker images can be built from source or pulled using `SyneRBI/SIRF-SuperBuild`, and containers created, by following the steps below.
 
 Please note that these instructions will mount the `SIRF-SuperBuild/docker/devel` folder on the host as `/devel` in the docker container.
-The container will copy
+When using a `service*` image, the container will copy
 [SIRF-Exercises] into this folder if not present. This means that
 files and notebooks in `/devel` will be persistent between sessions and
 even docker-image upgrades. You should therefore remove the contents of

--- a/docker/README.md
+++ b/docker/README.md
@@ -319,3 +319,20 @@ ERROR: for sirf  Cannot create container for service sirf: Unknown runtime speci
 ```
 Solution:
 Did you install the [NVidia container runtime][NVidia-container-runtime] and run the [Engine Setup](https://github.com/nvidia/nvidia-container-runtime#docker-engine-setup)?
+
+
+
+Problem: When trying to run `/sirf-compose-server-gpu up -d sirf` I get:
+```
+ERROR: The Compose file './docker-compose.srv-gpu.yml' is invalid because:
+Unsupported config option for services.gadgetron: 'runtime'
+Unsupported config option for services.sirf: 'runtime'
+```
+Solution:
+The most likely issue is that you have an old version of `docker-compose` (you need 1.19.0 or newer). Update your docker compose as (you may need root permissions). 
+Note that if you have python 2 and python 3 installed you may need to use `pip` instead of `pip3`, as your docker-compose may be installed in a different python version. 
+
+```
+pip3 uninstall docker-compose
+pip3 install docker-compose 
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -290,7 +290,7 @@ docker rmi <IMAGEID>
 
 - Tests can be run as follows:
 ```bash
-(py2) sirf:~$ /devel/test.sh
+(py2) sirf:~$ sudo -Hu jovyan bash --login -c /devel/test.sh
 ```
 - Currently all `compose` files call the container `sirf`. You could edit the `.yml` file if you
 want to run different versions.

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,7 @@
 Docker wrapper for CCP SyneRBI SIRF.
 
 ## TL;DR, I want a Jupyter notebook service NOW
+These instructions assume you have a knowledge of Docker and Docker Compose. If you don't it is highly recommended you keep reading ahead to [Introduction](#introduction) and beyond.
 
 1. Install [docker CE][docker-ce] and [`docker-compose`][docker-compose]. (If you are on a Mac, these are installed when you install [Docker Desktop](https://www.docker.com/products/docker-desktop)).
     - (optional) If you are on Linux/CentOS/similar and have a GPU,
@@ -17,6 +18,7 @@ and change directory to this folder, `SIRF-SuperBuild/docker`.
 3. Optionally pull the pre-built image with `docker pull synerbi/sirf:service` (or `docker pull synerbi/sirf:service-gpu`), otherwise
 the next line will build it, resulting in a much smaller download but longer build time.
 4. Run `./sirf-compose-server up -d sirf` (or `./sirf-compose-server-gpu up -d sirf`)
+    - You can use a `--build` flag in this command, or `./sirf-compose-server[-gpu] build` to re-build your image if you have an old version.
 5. Open a browser at <http://localhost:9999>.
 Note that starting the container may take a few seconds the first
 time, but will be very quick afterwards.
@@ -44,11 +46,36 @@ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' sir
 ```
 and use the resultant IP instead of `localhost` (e.g.: `172.18.0.2:9999`).
 
+## Introduction
+
+Docker is a low-overhead, container-based replacement for virtual machines (VMs).
+
+This works on Unix-type systems, MacOS and Windows 10, but best on a linux host system due to:
+
+1. Possibility to get CUDA support within the container
+2. `X11` windows displayed natively without needing e.g. a `vnc` server or desktop in the container
+
+This is probably the easiest way to directly use `SIRF` due to short
+installation instructions.
+
+
+## Prerequisites
+
+- Docker
+    + The free [Community Edition (CE)][docker-ce] is sufficient
+        + If you are installing on Linux, you will also have to follow the steps to [enable managing docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
+    + [`docker-compose`][docker-compose]
+    + If you are on Linux/CentOS/similar and have a GPU, install the [NVidia container runtime][NVidia-container-runtime].
+- The [`SIRF-SuperBuild` repository](https://github.com/SyneRBI/SIRF-SuperBuild)
+    + download and unzip or `git clone` this locally
+
 ## Tags
 
 The docker images are hosted at [hub.docker.com][dockerhub-SIRF]. We upload 2 types of images (see below for more information):
 - Command Line Interface (CLI)-only
-- "Service" images that will serve `Jupyter` notebooks 
+- "Service" images that will serve `Jupyter` notebooks
+
+And additionally the Docker Tag can specify a given SuperBuild version.
 
 To pull directly, use:
 
@@ -73,29 +100,6 @@ Service images are intended to be run in the background, and expose:
 
 [dockerhub-SIRF]: https://hub.docker.com/r/synerbi/sirf/
 [SuperBuild]: https://github.com/SyneRBI/SIRF-SuperBuild/
-
-## Introduction
-
-Docker is a low-overhead, container-based replacement for virtual machines (VMs).
-
-This works on Unix-type systems, MacOS and Windows 10, but best on a linux host system due to:
-
-1. Possibility to get CUDA support within the container
-2. `X11` windows displayed natively without needing e.g. a `vnc` server or desktop in the container
-
-This is probably the easiest way to directly use `SIRF` due to short
-installation instructions.
-
-
-## Prerequisites
-
-- Docker
-    + The free [Community Edition (CE)][docker-ce] is sufficient
-        + If you are installing on Linux, you will also have to follow the steps to [enable managing docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
-    + [`docker-compose`][docker-compose]
-    + If you are on Linux/CentOS/similar and have a GPU, install the [NVidia container runtime][NVidia-container-runtime].
-- The [`SIRF-SuperBuild` repository](https://github.com/SyneRBI/SIRF-SuperBuild)
-    + download and unzip or `git clone` this locally
 
 ### Windows specific notes
 
@@ -150,7 +154,8 @@ files and notebooks in `/devel` will be persistent between sessions and
 even docker-image upgrades. You should therefore remove the contents of
 `SIRF-SuperBuild/docker/devel` if you want to really start afresh.
 
-### Creating a container providing a Linux CLI with SIRF
+### Creating a container providing a Linux *CLI* with SIRF
+The default "CLI" images provide an Ubuntu environment with the SuperBuild built (see [Tags](#tags)) as a convenient environment.
 
 #### Using a Linux or MacOS CLI
 Build/pull the image:
@@ -158,26 +163,28 @@ Build/pull the image:
 # Either:
 SIRF-SuperBuild/docker$ docker pull synerbi/sirf
 # Or:
-SIRF-SuperBuild/docker$ docker-compose build core sirf
+SIRF-SuperBuild/docker$ ./sirf-compose build core sirf
 ```
 
+For easier file and window sharing, use the provided script, `sirf-compose`, which calls `docker-compose` but handles the host user's ID and some environment variables.
+
 We can now create a container.
-For easier file and window sharing, use the provided script (which calls `docker-compose` but handles the host user's ID and some environment variables):
 
 ```bash
 SIRF-SuperBuild/docker$ ./sirf-compose up --no-start sirf
 ```
 
-We can now use this interactively.
+Here, `--no-start` delays actually starting the container.
+We can now use this interactively, by starting the containder with flags `-ai`.
 ```bash
 SIRF-SuperBuild/docker$ docker start -ai sirf
-(py2) sirf:~$ gadgetron >> /dev/null &
-(py2) sirf:~$ python SIRF-SuperBuild/SIRF/examples/Python/MR/fully_sampled_recon.py
+(py2) sirf:~$ gadgetron >> /dev/null &  # we are free to use tools like Gadgetron
+(py2) sirf:~$ python SIRF-SuperBuild/SIRF/examples/Python/MR/fully_sampled_recon.py  # or SIRF
 (py2) sirf:~$ exit
 ```
 
 The first line starts the `sirf` docker container.
-The second line starts `gadgetron` within the container as a background process.
+The second line starts `gadgetron` within the container as a background process (optional, but needed for using Gadgetron of course).
 We can then run an example (or you could start an interactive python session).
 We then exit the container (which also stops it).
 
@@ -200,15 +207,18 @@ SIRF-SuperBuild/docker> docker-compose up --no-start sirf
 Using the container works in the same way as above.
 
 ### Creating a container providing a (Linux-based) Jupyter Server with SIRF
+The "server" images build upon the CLI images and automatically start a Jupyter service when run. These are convenient if you use Notebooks in your experiments, or are learning and want to run the [SIRF Exercises](https://github.com/SyneRBI/SIRF-Exercises).
 
 ```bash
 # Linux without GPU or MacOS:
 SIRF-SuperBuild/docker$ ./sirf-compose-server up -d sirf
 # Linux with GPU
-SIRF-SuperBuild/docker$ ./sirf-compose-server-gpu -d sirf
+SIRF-SuperBuild/docker$ ./sirf-compose-server-gpu up -d sirf
 # Windows:
 SIRF-SuperBuild/docker> sirf-compose-server up -d sirf
 ```
+(You may with to use the `--build` flag before `-d sirf` on any of the above commands to re-build the image at any point)
+
 This starts the `sirf` docker container, including `gadgetron` and
 `jupyter` within the container as background processes.
 
@@ -223,6 +233,12 @@ want to remove the container, you can use instead `./sirf-compose-server down`,
 see below.
 
 Please note that you cannot start a second `gadgetron` in a `service` container, as you would experience port conflicts.
+
+If you need a shell for any reason for your `service` container, you can ask the container to run Bash and drop into the shell using:
+
+```
+docker exec -w /devel -ti sirf /bin/bash
+```
 
 ### sirf-compose information 
 The `./sirf-compose*` scripts are simple wrappers around `docker-compose`.

--- a/docker/docker-compose.jupyterhub.yml
+++ b/docker/docker-compose.jupyterhub.yml
@@ -6,7 +6,7 @@ services:
   environment:
    GADGETRON_RELAY_HOST: 0.0.0.0
   build:
-   target: service
+   target: jupyterhub
    cache_from:
     - synerbi/sirf:core
     - synerbi/sirf:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,10 @@ services:
   build:
    context: .
    target: sirf
+   args:
+    SIRF_SB_URL: ${SIRF_SB_URL:-https://github.com/SyneRBI/SIRF-SuperBuild}
+    SIRF_SB_TAG: ${SIRF_SB_TAG:-master}
+    NUM_PARALLEL_BUILDS: ${NUM_PARALLEL_BUILDS:-2}
    cache_from:
     - synerbi/sirf:core
     - synerbi/sirf:latest

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,7 +36,7 @@ addgroup "$mainUser" users
 
 echo "$mainUser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/"$mainUser"
 
-for i in /opt/*-Exercises /opt/*-Demos "$HOME"; do
+for i in "$HOME"; do
   if [ -d "$i" ]; then
     echo "Updating file ownership for $i"
     chown -R $mainUser:$mainUser "$i"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-# This script is expected to be run as root
-# at container start-up time
+# This script is run at container start-up time
+
+if [ ! "$(id -u)" = 0 ]; then
+    # we're not root, just execute the argument(s)
+    exec "$@"
+fi
+
+# we are root
 
 # Add local user
 # Either use runtime USER_ID:GROUP_ID or fallback 1000:1000

--- a/docker/service.sh
+++ b/docker/service.sh
@@ -36,8 +36,11 @@ GCONFIG=./INSTALL/share/gadgetron/config/gadgetron.xml
 [ -f ./INSTALL/bin/gadgetron ] \
   && ./INSTALL/bin/gadgetron >& ~/gadgetron.log&
 
-echo "make sure the SIRF-Exercises are in the expected location (/devel in the container)"
-cd /devel
+echo "make sure the SIRF-Exercises are in the expected location"
+# if /devel exists, put it there
+[ -d /devel ] && cd /devel
+# otherwise, put it in the home directory
+[ ! -d /devel ] && cd ~
 [ -d SIRF-Exercises ] || cp -a $SIRF_PATH/../../../SIRF-Exercises .
 # link SIRF-Contrib into it
 if [ ! -r SIRF-contrib ]; then

--- a/docker/service.sh
+++ b/docker/service.sh
@@ -39,6 +39,11 @@ GCONFIG=./INSTALL/share/gadgetron/config/gadgetron.xml
 echo "make sure the SIRF-Exercises are in the expected location (/devel in the container)"
 cd /devel
 [ -d SIRF-Exercises ] || cp -a $SIRF_PATH/../../../SIRF-Exercises .
+# link SIRF-Contrib into it
+if [ ! -r SIRF-contrib ]; then
+    echo "Creating link to SIRF-contrib"
+    ln -s "$SIRF_INSTALL_PATH"/python/sirf/contrib SIRF-contrib
+fi
 
 echo "start jupyter"
 if [ ! -f ~/.jupyter/jupyter_notebook_config.py ]; then

--- a/docker/user_sirf-ubuntu.sh
+++ b/docker/user_sirf-ubuntu.sh
@@ -2,9 +2,15 @@
 [ -f .bashrc ] && . .bashrc
 set -ev
 INSTALL_DIR="${1:-/opt}"
-# SIRF
-git clone https://github.com/SyneRBI/SIRF-SuperBuild --recursive -b master $INSTALL_DIR/SIRF-SuperBuild
-pushd $INSTALL_DIR/SIRF-SuperBuild
+# set default URL/tag
+: ${SIRF_SB_URL=https://github.com/SyneRBI/SIRF-SuperBuild}
+: ${SIRF_SB_TAG=master}
+# set default number of parallel builds
+: ${NUM_PARALLEL_BUILDS=2}
+
+git clone "$SIRF_SB_URL" --recursive "$INSTALL_DIR"/SIRF-SuperBuild
+cd $INSTALL_DIR/SIRF-SuperBuild
+git checkout "$SIRF_SB_TAG"
 
 COMPILER_FLAGS="-DCMAKE_C_COMPILER='$(which gcc)' -DCMAKE_CXX_COMPILER='$(which g++)'"
 echo $PATH
@@ -12,6 +18,4 @@ echo $COMPILER_FLAGS
 echo $BUILD_FLAGS $EXTRA_BUILD_FLAGS
 cmake $BUILD_FLAGS $EXTRA_BUILD_FLAGS $COMPILER_FLAGS .
 
-cmake --build . -j 2
-
-popd
+cmake --build . -j ${NUM_PARALLEL_BUILDS}

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -190,7 +190,7 @@ if (DEVEL_BUILD)
   set(DEFAULT_CCPi-Regularisation-Toolkit_TAG origin/master)
 
 else()
-  set(DEFAULT_SIRF_TAG c8f808acf5324b4ed56360362f369a1dd693f33d)
+  set(DEFAULT_SIRF_TAG 17f7fa91704b0b5309d1e2562489aaf7932875e8)
 #  set(DEFAULT_SIRF_TAG v3.0.0)
 
   ## STIR

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -190,7 +190,7 @@ if (DEVEL_BUILD)
   set(DEFAULT_CCPi-Regularisation-Toolkit_TAG origin/master)
 
 else()
-  set(DEFAULT_SIRF_TAG 58961137baddb2054405e9c7de647adc62ade7fe)
+  set(DEFAULT_SIRF_TAG c8f808acf5324b4ed56360362f369a1dd693f33d)
 #  set(DEFAULT_SIRF_TAG v3.0.0)
 
   ## STIR

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -190,8 +190,7 @@ if (DEVEL_BUILD)
   set(DEFAULT_CCPi-Regularisation-Toolkit_TAG origin/master)
 
 else()
-  set(DEFAULT_SIRF_TAG 17f7fa91704b0b5309d1e2562489aaf7932875e8)
-#  set(DEFAULT_SIRF_TAG v3.0.0)
+  set(DEFAULT_SIRF_TAG v3.1.0-rc.1)
 
   ## STIR
   set(DEFAULT_STIR_URL https://github.com/UCL/STIR )

--- a/version_config.cmake
+++ b/version_config.cmake
@@ -149,7 +149,7 @@ set(DEFAULT_JSON_TAG v3.9.1)
 
 # CCPi CIL
 set(DEFAULT_CIL_URL https://github.com/TomographicImaging/CIL.git)
-set(DEFAULT_CIL_TAG "ca12ef252e68eaa7a3cccd19250e5481f02bcfd2")
+set(DEFAULT_CIL_TAG "b81326291c6061d57fa332a248cb9d15d9f957eb")
 set(DEFAULT_CIL-ASTRA_URL https://github.com/TomographicImaging/CIL-ASTRA.git)
 set(DEFAULT_CIL-ASTRA_TAG "v21.2.0")
 set(DEFAULT_CCPi-Regularisation-Toolkit_URL https://github.com/vais-ral/CCPi-Regularisation-Toolkit.git)


### PR DESCRIPTION
- merged `master` again
- fixed `docker-compose.jupyterhub.yml` (was using wrong `target`, which would explain why it was using `entrypoint.sh` on jupyterhub if Alex was running that image)
- change `service.sh` to put exercises in `~` if `/devel` doesn't exist.

This might fix it, but I'm not so happy with it.